### PR TITLE
changing flink image for deploying demos to previous version of flink

### DIFF
--- a/docker/flink/application-cluster/docker-compose.yml
+++ b/docker/flink/application-cluster/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   jobmanager:
-    image: flink:latest
+    image: flink:1.20.3-scala_2.12-java8
     ports:
       - "8081:8081"
     command: standalone-job --job-classname com.job.ClassName
@@ -14,7 +14,7 @@ services:
         parallelism.default: 2
 
   taskmanager:
-    image: flink:latest
+    image: flink:1.20.3-scala_2.12-java8
     depends_on:
       - jobmanager
     command: taskmanager

--- a/docker/flink/session-cluster/docker-compose.yml
+++ b/docker/flink/session-cluster/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   jobmanager:
-    image: flink:latest
+    image: flink:1.20.3-scala_2.12-java8
     ports:
       - "8081:8081"
     volumes:
@@ -13,7 +13,7 @@ services:
         jobmanager.rpc.address: jobmanager
 
   taskmanager:
-    image: flink:latest
+    image: flink:1.20.3-scala_2.12-java8
     depends_on:
       - jobmanager
     command: taskmanager


### PR DESCRIPTION
Hi in case you want to merge, in my case with the latest version of flink this lecture didn't work for hte application cluster it faiil silenty and for the session cluster was throwing the exception java.lang.ClassNotFoundException: org.apache.flink.streaming.api.scala.StreamExecutionEnvironment, that latest version that i was able to maket it work was this  